### PR TITLE
change travel time fn / add arrival time fn

### DIFF
--- a/contracts/settling_game/modules/travel/Travel.cairo
+++ b/contracts/settling_game/modules/travel/Travel.cairo
@@ -195,7 +195,7 @@ func get_travel_information{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, rang
 }
 
 @view
-func get_travel_time{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+func get_arrival_time{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     traveller_coordinates: Point, destination_coordinates: Point
 ) -> (time: felt) {
     // get distance between two points
@@ -207,6 +207,19 @@ func get_travel_time{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check
     let (now) = get_block_timestamp();
 
     return (time + now,);
+}
+
+@view
+func get_travel_time{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    traveller_coordinates: Point, destination_coordinates: Point
+) -> (time: felt) {
+    // get distance between two points
+    let (distance) = get_travel_distance(traveller_coordinates, destination_coordinates);
+
+    // calculate time
+    let (time) = Travel.calculate_time(distance);
+
+    return (time,);
 }
 
 @view


### PR DESCRIPTION
Current `Travel.get_travel_time` function: 
```cairo
@view
func get_arrival_time{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
    traveller_coordinates: Point, destination_coordinates: Point
) -> (time: felt) {
    // get distance between two points
    let (distance) = get_travel_distance(traveller_coordinates, destination_coordinates);

    // calculate time
    let (time) = Travel.calculate_time(distance);

    let (now) = get_block_timestamp();

    return (time + now,);
}
```

New `get_travel_time` function:
```cairo

@view
func get_travel_time{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
    traveller_coordinates: Point, destination_coordinates: Point
) -> (time: felt) {
    // get distance between two points
    let (distance) = get_travel_distance(traveller_coordinates, destination_coordinates);

    // calculate time
    let (time) = Travel.calculate_time(distance);

    return (time,);
}
```

New `get_arrival_time` function:
```cairo
@view
func get_arrival_time{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
    traveller_coordinates: Point, destination_coordinates: Point
) -> (time: felt) {
    // get distance between two points
    let (distance) = get_travel_distance(traveller_coordinates, destination_coordinates);

    // calculate time
    let (time) = Travel.calculate_time(distance);

    let (now) = get_block_timestamp();

    return (time + now,);
}
```

This is taking the travel time and adding the current timestamp, returning the timestamp at arrival. I think this is more appropriate to call this `get_arrival_time` returning the timestamp at arrival and creating a function `get_travel_time` simply returning the time of the travel.

This is not *very* important, but I think this function maybe be used a lot and can be confusing. Hope small PRs like those are welcomed