### PR TITLE
resolves #289 by providing lib functions for assigning canonical item…

### DIFF
--- a/contracts/loot/constants/item.cairo
+++ b/contracts/loot/constants/item.cairo
@@ -177,6 +177,140 @@ namespace Slot {
     const Ring = 8;
 }
 
+const NamePrefixLength = 69;
+const NameSuffixLength = 18;
+const ItemSuffixLength = 16;
+
+namespace SlotItemsLength {
+    const Weapon = 18;
+    const Chest = 15;
+    const Head = 15;
+    const Waist = 15;
+    const Foot = 15;
+    const Hand = 15;
+    const Neck = 3;
+    const Ring = 5;
+}
+
+namespace ItemIndex {
+    // Weapon
+    const Warhammer = 0;
+    const Quarterstaff = 1;
+    const Maul = 2;
+    const Mace = 3;
+    const Club = 4;
+    const Katana = 5;
+    const Falchion = 6;
+    const Scimitar = 7;
+    const LongSword = 8;
+    const ShortSword = 9;
+    const GhostWand = 10;
+    const GraveWand = 11;
+    const BoneWand = 12;
+    const Wand = 13;
+    const Grimoire = 14;
+    const Chronicle = 15;
+    const Tome = 16;
+    const Book = 17;
+
+    // Chest
+    const DivineRobe = 0;
+    const SilkRobe = 1;
+    const LinenRobe = 2;
+    const Robe = 3;
+    const Shirt = 4;
+    const DemonHusk = 5;
+    const DragonskinArmor = 6;
+    const StuddedLeatherArmor = 7;
+    const HardLeatherArmor = 8;
+    const LeatherArmor = 9;
+    const HolyChestplate = 10;
+    const OrnateChestplate = 11;
+    const PlateMail = 12;
+    const ChainMail = 13;
+    const RingMail = 14;
+
+    // Head
+    const AncientHelm = 0;
+    const OrnateHelm = 1;
+    const GreatHelm = 2;
+    const FullHelm = 3;
+    const Helm = 4;
+    const DemonCrown = 5;
+    const DragonsCrown = 6;
+    const WarCap = 7;
+    const LeatherCap = 8;
+    const Cap = 9;
+    const Crown = 10;
+    const DivineHood = 11;
+    const SilkHood = 12;
+    const LinenHood = 13;
+    const Hood = 14;
+
+    // Waist
+    const OrnateBelt = 0;
+    const WarBelt = 1;
+    const PlatedBelt = 2;
+    const MeshBelt = 3;
+    const HeavyBelt = 4;
+    const DemonhideBelt = 5;
+    const DragonskinBelt = 6;
+    const StuddedLeatherBelt = 7;
+    const HardLeatherBelt = 8;
+    const LeatherBelt = 9;
+    const BrightsilkSash = 10;
+    const SilkSash = 11;
+    const WoolSash = 12;
+    const LinenSash = 13;
+    const Sash = 14;
+
+    // Foot
+    const HolyGreaves = 0;
+    const OrnateGreaves = 1;
+    const Greaves = 2;
+    const ChainBoots = 3;
+    const HeavyBoots = 4;
+    const DemonhideBoots = 5;
+    const DragonskinBoots = 6;
+    const StuddedLeatherBoots = 7;
+    const HardLeatherBoots = 8;
+    const LeatherBoots = 9;
+    const DivineSlippers = 10;
+    const SilkSlippers = 11;
+    const WoolShoes = 12;
+    const LinenShoes = 13;
+    const Shoes = 14;
+
+    // Hand
+    const HolyGauntlets = 0;
+    const OrnateGauntlets = 1;
+    const Gauntlets = 2;
+    const ChainGloves = 3;
+    const HeavyGloves = 4;
+    const DemonsHands = 5;
+    const DragonskinGloves = 6;
+    const StuddedLeatherGloves = 7;
+    const HardLeatherGloves = 8;
+    const LeatherGloves = 9;
+    const DivineGloves = 10;
+    const SilkGloves = 11;
+    const WoolGloves = 12;
+    const LinenGloves = 13;
+    const Gloves = 14;
+
+    // Necklaces
+    const Necklace = 0;
+    const Amulet = 1;
+    const Pendant = 2;
+
+    // Rings
+    const GoldRing = 0;
+    const SilverRing = 1;
+    const BronzeRing = 2;
+    const PlatinumRing = 3;
+    const TitaniumRing = 4;
+}
+
 namespace ItemSlot {
     const Pendant = Slot.Neck;
     const Necklace = Slot.Neck;

--- a/contracts/loot/loot/library.cairo
+++ b/contracts/loot/loot/library.cairo
@@ -5,7 +5,7 @@ from starkware.cairo.common.math import unsigned_div_rem
 from starkware.cairo.common.math_cmp import is_le
 from starkware.starknet.common.syscalls import get_block_timestamp
 
-from contracts.loot.constants.item import Item
+from contracts.loot.constants.item import Item, NamePrefixLength, NameSuffixLength, ItemSuffixLength
 from contracts.loot.loot.stats.item import ItemStats
 from contracts.settling_game.utils.general import unpack_data
 
@@ -147,11 +147,12 @@ namespace ItemLib {
 
     // @notice Assigns a name prefix to a Loot item using the same schema as the OG Loot Contract
     // @param item: The Loot Item you want to assign a name prefix to
+    // @param rnd: A random number
     // @return updated_item: The provided item with a canoncially sound name prefix added
-    func assign_item_name_prefix{syscall_ptr: felt*, range_check_ptr}(item: Item) -> (
+    func assign_item_name_prefix{syscall_ptr: felt*, range_check_ptr}(item: Item, rnd: felt) -> (
         updated_item: Item
     ) {
-        let (updated_name_prefix) = generate_name_prefix(item.Id);
+        let (updated_name_prefix) = generate_name_prefix(item.Id, rnd);
 
         let updated_item = Item(
             Id=item.Id,
@@ -172,10 +173,11 @@ namespace ItemLib {
         return updated_item;
     }
 
-    // @notice Returns a name prefix for the provided item that is consistent with the Loot Contract
+    // @notice Returns a name prefix for the provided random number that is consistent with the Loot Contract
     // @param item_id: The id of the item to get a name prefix for
-    // TODO #289: Implement this function
-    func generate_name_prefix{syscall_ptr: felt*, range_check_ptr}(item_id: felt) -> (
+    // @param rnd: A random number
+    // @return The name prefix
+    func generate_name_prefix{syscall_ptr: felt*, range_check_ptr}(item_id: felt, rnd: felt) -> (
         name_prefix: felt
     ) {
         // The Loot contract assigns the name prefixes here:
@@ -201,20 +203,26 @@ namespace ItemLib {
         //  Mind, Oblivion, Pandemonium, Rage, Skull, Sorrow, Tempest, Victory, Woe}
         //
         // If a katana is passed into this function, it should return one of the above names and only one of those
+        let (item_slot) = ItemStats.item_slot(item_id);
+        let (loot_slot_length) = ItemStats.loot_slot_length(item_slot);
+        let (loot_item_index) = ItemStats.loot_item_index(item_id);
+        // find a new random number that respects Loot constraints
+        let new_rnd = rnd * loot_slot_length + loot_item_index;
 
-        // I'll leave it to the author of this function to figure out how the Loot contract achieves the above and
-        // how best to mimic this behavior in this function. Good luck adventurer!
+        let (_, index) = unsigned_div_rem(new_rnd, NamePrefixLength);
+        let (name_prefix) = ItemStats.item_name_prefix(index + 1);
 
-        return (1,);
+        return (name_prefix,);
     }
 
     // @notice Assigns a name suffix to a Loot item using the same schema as the OG Loot Contract
     // @param item: The Loot Item you want to assign a name suffix to
+    // @param rnd: A random number
     // @return updated_item: The provided item with a canoncially sound name suffix added
-    func assign_item_name_suffix{syscall_ptr: felt*, range_check_ptr}(item: Item) -> (
+    func assign_item_name_suffix{syscall_ptr: felt*, range_check_ptr}(item: Item, rnd: felt) -> (
         updated_item: Item
     ) {
-        let (updated_name_suffix) = generate_name_suffix(item.Id);
+        let (updated_name_suffix) = generate_name_suffix(rnd);
 
         let updated_item = Item(
             Id=item.Id,
@@ -237,9 +245,9 @@ namespace ItemLib {
 
     // @notice Returns a name suffix for the provided item that is consistent with the Loot Contract
     // @param item_id: The id of a Loot
+    // @param rnd: A random number
     // @return name_suffix for the item
-    // TODO #289: Implement this function
-    func generate_name_suffix{syscall_ptr: felt*, range_check_ptr}(item_id: felt) -> (
+    func generate_name_suffix{syscall_ptr: felt*, range_check_ptr}(item_id: felt, rnd: felt) -> (
         name_suffix: felt
     ) {
         // The Loot contract assigns the name suffixes here:
@@ -272,18 +280,23 @@ namespace ItemLib {
         // "Sun",
         // "Moon"
         // ];
+        let (item_slot) = ItemStats.item_slot(item_id);
+        let (loot_slot_length) = ItemStats.loot_slot_length(item_slot);
+        let (loot_item_index) = ItemStats.loot_item_index(item_id);
+        // find a new random number that respects Loot constraints
+        let new_rnd = rnd * loot_slot_length + loot_item_index;
 
-        // I'll leave it to the author of this function to figure out how the Loot contract achieves the above and
-        // how best to mimic this behavior in this function. Good luck adventurer!
-
-        return (1,);
+        let (_, index) = unsigned_div_rem(new_rnd, NameSuffixLength);
+        let (name_suffix) = ItemStats.item_name_suffix(index + 1);
+        return (name_suffix,);
     }
 
     // @notice Assigns a suffix to a Loot item using the same schema as the OG Loot Contract
     // @param item: The Loot Item you want to assign a suffix to
+    // @param rnd: A random number
     // @return updated_item: The provided item with a canoncially sound suffix added
-    func assign_item_suffix{syscall_ptr: felt*, range_check_ptr}(item: Item) -> Item {
-        let (updated_suffix) = generate_item_suffix(item.Id);
+    func assign_item_suffix{syscall_ptr: felt*, range_check_ptr}(item: Item, rnd: felt) -> Item {
+        let (updated_suffix) = generate_item_suffix(rnd);
 
         let updated_item = Item(
             Id=item.Id,
@@ -304,11 +317,11 @@ namespace ItemLib {
         return updated_item;
     }
 
-    // @notice Returns a name suffix for the provided item that is consistent with the Loot Contract
+    // @notice Returns an item suffix for the provided item that is consistent with the Loot Contract
     // @param item_id: The id of the item to get a name prefix for
-    // TODO #289: Implement this function
-    func generate_item_suffix{syscall_ptr: felt*, range_check_ptr}(item_id: felt) -> (
-        name_suffix: felt
+    // @param rnd: A random number
+    func generate_item_suffix{syscall_ptr: felt*, range_check_ptr}(item_id: felt, rnd: felt) -> (
+        item_suffix: felt
     ) {
         // The Loot contract assigns the item suffix here:
         // https://etherscan.io/token/0xff9c1b15b16263c61d017ee9f65c50e4ae0113d7#code#L1510
@@ -343,9 +356,14 @@ namespace ItemLib {
         //     "of the Twins"
         // ];
 
-        // I'll leave it to the author of this function to figure out how the Loot contract achieves the above and
-        // how best to mimic this behavior in this function. Good luck adventurer!
+        let (item_slot) = ItemStats.item_slot(item_id);
+        let (loot_slot_length) = ItemStats.loot_slot_length(item_slot);
+        let (loot_item_index) = ItemStats.loot_item_index(item_id);
+        // find a new random number that respects Loot constraints
+        let new_rnd = rnd * loot_slot_length + loot_item_index;
 
-        return (1,);
+        let (_, index) = unsigned_div_rem(new_rnd, ItemSuffixLength);
+        let (item_suffix) = ItemStats.item_suffix(index + 1);
+        return (item_suffix,);
     }
 }

--- a/contracts/loot/loot/stats/item.cairo
+++ b/contracts/loot/loot/stats/item.cairo
@@ -15,6 +15,8 @@ from starkware.cairo.common.registers import get_label_location
 from contracts.loot.constants.item import (
     ItemIds,
     ItemSlot,
+    ItemIndex,
+    SlotItemsLength,
     ItemType,
     ItemMaterial,
     ItemNamePrefixes,
@@ -133,6 +135,129 @@ namespace ItemStats {
         dw ItemSlot.Gauntlets;
         dw ItemSlot.ChainGloves;
         dw ItemSlot.HeavyGloves;
+    }
+
+    func loot_slot_length{syscall_ptr: felt*, range_check_ptr}(slot: felt) -> (slot_length: felt) {
+        let (label_location) = get_label_location(labels);
+        return ([label_location + slot - 1],);
+
+        labels:
+        dw SlotItemsLength.Weapon;
+        dw SlotItemsLength.Chest;
+        dw SlotItemsLength.Head;
+        dw SlotItemsLength.Waist;
+        dw SlotItemsLength.Foot;
+        dw SlotItemsLength.Hand;
+        dw SlotItemsLength.Neck;
+        dw SlotItemsLength.Ring;
+    }
+
+    func loot_item_index{syscall_ptr: felt*, range_check_ptr}(item_id: felt) -> (item_index: felt) {
+        let (label_location) = get_label_location(labels);
+        return ([label_location + item_id - 1],);
+
+        labels:
+        dw ItemIndex.Pendant;
+        dw ItemIndex.Necklace;
+        dw ItemIndex.Amulet;
+        dw ItemIndex.SilverRing;
+        dw ItemIndex.BronzeRing;
+        dw ItemIndex.PlatinumRing;
+        dw ItemIndex.TitaniumRing;
+        dw ItemIndex.GoldRing;
+        dw ItemIndex.GhostWand;
+        dw ItemIndex.GraveWand;
+        dw ItemIndex.BoneWand;
+        dw ItemIndex.Wand;
+        dw ItemIndex.Grimoire;
+        dw ItemIndex.Chronicle;
+        dw ItemIndex.Tome;
+        dw ItemIndex.Book;
+        dw ItemIndex.DivineRobe;
+        dw ItemIndex.SilkRobe;
+        dw ItemIndex.LinenRobe;
+        dw ItemIndex.Robe;
+        dw ItemIndex.Shirt;
+        dw ItemIndex.Crown;
+        dw ItemIndex.DivineHood;
+        dw ItemIndex.SilkHood;
+        dw ItemIndex.LinenHood;
+        dw ItemIndex.Hood;
+        dw ItemIndex.BrightsilkSash;
+        dw ItemIndex.SilkSash;
+        dw ItemIndex.WoolSash;
+        dw ItemIndex.LinenSash;
+        dw ItemIndex.Sash;
+        dw ItemIndex.DivineSlippers;
+        dw ItemIndex.SilkSlippers;
+        dw ItemIndex.WoolShoes;
+        dw ItemIndex.LinenShoes;
+        dw ItemIndex.Shoes;
+        dw ItemIndex.DivineGloves;
+        dw ItemIndex.SilkGloves;
+        dw ItemIndex.WoolGloves;
+        dw ItemIndex.LinenGloves;
+        dw ItemIndex.Gloves;
+        dw ItemIndex.Katana;
+        dw ItemIndex.Falchion;
+        dw ItemIndex.Scimitar;
+        dw ItemIndex.LongSword;
+        dw ItemIndex.ShortSword;
+        dw ItemIndex.DemonHusk;
+        dw ItemIndex.DragonskinArmor;
+        dw ItemIndex.StuddedLeatherArmor;
+        dw ItemIndex.HardLeatherArmor;
+        dw ItemIndex.LeatherArmor;
+        dw ItemIndex.DemonCrown;
+        dw ItemIndex.DragonsCrown;
+        dw ItemIndex.WarCap;
+        dw ItemIndex.LeatherCap;
+        dw ItemIndex.Cap;
+        dw ItemIndex.DemonhideBelt;
+        dw ItemIndex.DragonskinBelt;
+        dw ItemIndex.StuddedLeatherBelt;
+        dw ItemIndex.HardLeatherBelt;
+        dw ItemIndex.LeatherBelt;
+        dw ItemIndex.DemonhideBoots;
+        dw ItemIndex.DragonskinBoots;
+        dw ItemIndex.StuddedLeatherBoots;
+        dw ItemIndex.HardLeatherBoots;
+        dw ItemIndex.LeatherBoots;
+        dw ItemIndex.DemonsHands;
+        dw ItemIndex.DragonskinGloves;
+        dw ItemIndex.StuddedLeatherGloves;
+        dw ItemIndex.HardLeatherGloves;
+        dw ItemIndex.LeatherGloves;
+        dw ItemIndex.Warhammer;
+        dw ItemIndex.Quarterstaff;
+        dw ItemIndex.Maul;
+        dw ItemIndex.Mace;
+        dw ItemIndex.Club;
+        dw ItemIndex.HolyChestplate;
+        dw ItemIndex.OrnateChestplate;
+        dw ItemIndex.PlateMail;
+        dw ItemIndex.ChainMail;
+        dw ItemIndex.RingMail;
+        dw ItemIndex.AncientHelm;
+        dw ItemIndex.OrnateHelm;
+        dw ItemIndex.GreatHelm;
+        dw ItemIndex.FullHelm;
+        dw ItemIndex.Helm;
+        dw ItemIndex.OrnateBelt;
+        dw ItemIndex.WarBelt;
+        dw ItemIndex.PlatedBelt;
+        dw ItemIndex.MeshBelt;
+        dw ItemIndex.HeavyBelt;
+        dw ItemIndex.HolyGreaves;
+        dw ItemIndex.OrnateGreaves;
+        dw ItemIndex.Greaves;
+        dw ItemIndex.ChainBoots;
+        dw ItemIndex.HeavyBoots;
+        dw ItemIndex.HolyGauntlets;
+        dw ItemIndex.OrnateGauntlets;
+        dw ItemIndex.Gauntlets;
+        dw ItemIndex.ChainGloves;
+        dw ItemIndex.HeavyGloves;
     }
 
     func item_type{syscall_ptr: felt*, range_check_ptr}(item_id: felt) -> (type: felt) {

--- a/tests/protostar/loot/loot/test_loot.cairo
+++ b/tests/protostar/loot/loot/test_loot.cairo
@@ -1,13 +1,26 @@
 %lang starknet
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
-from contracts.loot.constants.item import ItemIds, ItemNamePrefixes, ItemNameSuffixes, ItemSuffixes
-from contracts.loot.loot.library import ItemLib
 from starkware.cairo.common.math import assert_not_equal
 
-// TODO #289: pass these tests
+from contracts.loot.constants.item import ItemIds, ItemNamePrefixes, ItemNameSuffixes, ItemSuffixes
+from contracts.loot.loot.library import ItemLib
+from contracts.loot.loot.stats.item import ItemStats
+
 @external
-func test_generate_name_prefix{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+func setup_generate_name_prefix{syscall_ptr: felt*, range_check_ptr}() {
+    %{
+        given(
+            rnd = strategy.integers(0, 101),
+        )
+    %}
+    return ();
+}
+
+@external
+func test_generate_name_prefix{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    rnd: felt
+) {
     alloc_locals;
 
     // https://github.com/Anish-Agnihotri/dhof-loot/blob/master/output/occurences.json
@@ -16,7 +29,7 @@ func test_generate_name_prefix{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, r
     // Katanas can only receive the following name prefixes:
     // { Armageddon, Blight, Brimstone, Cataclysm, Corruption, Demon, Dread, Eagle, Foe, Gloom, Grim, Honour, Kraken
     //   Mind, Oblivion, Pandemonium, Rage, Skull, Sorrow, Tempest, Victory, Woe }
-    let (katana_name_prefix) = ItemLib.generate_name_prefix(ItemIds.Katana);
+    let (katana_name_prefix) = ItemLib.generate_name_prefix(ItemIds.Katana, rnd);
 
     // Verify function worked by asserting it did not return any of the names not in the above list
     assert_not_equal(katana_name_prefix, ItemNamePrefixes.Agony);
@@ -66,7 +79,7 @@ func test_generate_name_prefix{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, r
     assert_not_equal(katana_name_prefix, ItemNamePrefixes.Wrath);
     assert_not_equal(katana_name_prefix, ItemNamePrefixes.Lights);
 
-    let (divine_hood_name_prefix) = ItemLib.generate_name_prefix(ItemIds.DivineHood);
+    let (divine_hood_name_prefix) = ItemLib.generate_name_prefix(ItemIds.DivineHood, rnd);
     assert_not_equal(divine_hood_name_prefix, ItemNamePrefixes.Agony);
     assert_not_equal(divine_hood_name_prefix, ItemNamePrefixes.Apocalypse);
     assert_not_equal(divine_hood_name_prefix, ItemNamePrefixes.Beast);
@@ -114,7 +127,7 @@ func test_generate_name_prefix{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, r
     assert_not_equal(divine_hood_name_prefix, ItemNamePrefixes.Wrath);
     assert_not_equal(divine_hood_name_prefix, ItemNamePrefixes.Lights);
 
-    let (demonhide_belt_name_prefix) = ItemLib.generate_name_prefix(ItemIds.DemonhideBelt);
+    let (demonhide_belt_name_prefix) = ItemLib.generate_name_prefix(ItemIds.DemonhideBelt, rnd);
     assert_not_equal(demonhide_belt_name_prefix, ItemNamePrefixes.Agony);
     assert_not_equal(demonhide_belt_name_prefix, ItemNamePrefixes.Apocalypse);
     assert_not_equal(demonhide_belt_name_prefix, ItemNamePrefixes.Beast);
@@ -165,25 +178,36 @@ func test_generate_name_prefix{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, r
     return ();
 }
 
-// TODO #289: pass these tests
 @external
-func test_generate_name_suffix{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+func setup_generate_name_suffix{syscall_ptr: felt*, range_check_ptr}() {
+    %{
+        given(
+            rnd = strategy.integers(0, 101),
+        )
+    %}
+    return ();
+}
+
+@external
+func test_generate_name_suffix{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    rnd: felt
+) {
     alloc_locals;
 
     // https://github.com/Anish-Agnihotri/dhof-loot/blob/master/output/occurences.json
     // is a good resource for verifying Loot item name info
 
     // Katanas are always "X Grasp" Katana of Y
-    let (katana_name_suffix) = ItemLib.generate_name_suffix(ItemIds.Katana);
+    let (katana_name_suffix) = ItemLib.generate_name_suffix(ItemIds.Katana, rnd);
     assert katana_name_suffix = ItemNameSuffixes.Grasp;
 
-    // Grimoires are always "X Peak" Katana of Y
-    let (grimoire_name_suffix) = ItemLib.generate_name_suffix(ItemIds.Grimoire);
+    // Grimoires are always "X Peak" Grimoire of Y
+    let (grimoire_name_suffix) = ItemLib.generate_name_suffix(ItemIds.Grimoire, rnd);
     assert grimoire_name_suffix = ItemNameSuffixes.Peak;
 
     // Divine Hoods can have {Bender, Grasp, Moon, Peak, Shout, Bite} for their name suffix
     // so we assert function does not return any of the other name suffixes
-    let (divine_hood_name_suffix) = ItemLib.generate_name_suffix(ItemIds.DivineHood);
+    let (divine_hood_name_suffix) = ItemLib.generate_name_suffix(ItemIds.DivineHood, rnd);
     assert_not_equal(divine_hood_name_suffix, ItemNameSuffixes.Bane);
     assert_not_equal(divine_hood_name_suffix, ItemNameSuffixes.Root);
     assert_not_equal(divine_hood_name_suffix, ItemNameSuffixes.Song);
@@ -198,9 +222,8 @@ func test_generate_name_suffix{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, r
     assert_not_equal(divine_hood_name_suffix, ItemNameSuffixes.Sun);
 
     // Gold Rings can have any of the name suffixes except for {Bane, Bite,Instrument, Shadow, Growl, Form}
-    let (gold_ring_name_suffix) = ItemLib.generate_name_suffix(ItemIds.GoldRing);
+    let (gold_ring_name_suffix) = ItemLib.generate_name_suffix(ItemIds.GoldRing, rnd);
     assert_not_equal(divine_hood_name_suffix, ItemNameSuffixes.Bane);
-    assert_not_equal(divine_hood_name_suffix, ItemNameSuffixes.Bite);
     assert_not_equal(divine_hood_name_suffix, ItemNameSuffixes.Instrument);
     assert_not_equal(divine_hood_name_suffix, ItemNameSuffixes.Shadow);
     assert_not_equal(divine_hood_name_suffix, ItemNameSuffixes.Growl);
@@ -209,9 +232,20 @@ func test_generate_name_suffix{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, r
     return ();
 }
 
-// TODO #289: pass these tests
 @external
-func test_generate_item_suffix{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+func setup_generate_item_suffix{syscall_ptr: felt*, range_check_ptr}() {
+    %{
+        given(
+            rnd = strategy.integers(0, 101),
+        )
+    %}
+    return ();
+}
+
+@external
+func test_generate_item_suffix{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    rnd: felt
+) {
     alloc_locals;
 
     // https://github.com/Anish-Agnihotri/dhof-loot/blob/master/output/occurences.json
@@ -219,7 +253,7 @@ func test_generate_item_suffix{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, r
 
     // Katanas only receive the suffixes/Orders:
     // {of Giants, of Skill, of Brilliance, of Protection, of Rage, of Vitriol, of Detection, of the Twins}
-    let (katana_suffix) = ItemLib.generate_item_suffix(ItemIds.Katana);
+    let (katana_suffix) = ItemLib.generate_item_suffix(ItemIds.Katana, rnd);
 
     // Verify function works by asserting it did not respond one of the other suffixes/orders
     assert_not_equal(katana_suffix, ItemSuffixes.of_Power);
@@ -233,7 +267,7 @@ func test_generate_item_suffix{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, r
 
     // Grimoires only receive the suffixes/Orders:
     // {of Power, of Titans, of Perfection, of Enlightenment, of Anger, of Fury, of the Fox, of Reflection}
-    let (grimoire_suffix) = ItemLib.generate_item_suffix(ItemIds.Grimoire);
+    let (grimoire_suffix) = ItemLib.generate_item_suffix(ItemIds.Grimoire, rnd);
 
     // Verify function works by asserting it did not respond one of the other suffixes/orders
     assert_not_equal(grimoire_suffix, ItemSuffixes.of_Giant);


### PR DESCRIPTION
This fixes #289 by providing lib functions for assigning canonical item names. 

## Description
I've implemented a logic close to the original Loot contract. The main differences come from the divergences in implementation between Realms and Loot:
1. In Loot the same random number is used for both defining the item_id and the name_prefix/suffix + item_suffix (NP/NS/IS), while in Realms it's done in 2 steps (through **generate_random_item** first and then **set_item** for NP/NS/IS). Normally you would need to use the same random number to make sure item_id is consistent with NP/NS/IS. The way I tackle this is by using the random number given as a generator for an alternate random number that respects the outcome of the Loot contract for a particular item_id.
You can see an example of this here: https://github.com/aymericdelab/realms-contracts-aymeric/blob/289-provide-lib-functions-for-assigning-canonical-item-names/contracts/loot/loot/library.cairo#L210
2.  In Loot, the 101 items are separated into different lists for each slot. In Realms, we have only one list for all the items, and the order is different. This part is important for getting the same outcomes as for Loot and having only Grasp name_suffix for Katanas for example. To tackle this I've introduce a **loot_item_index** function that retrieves the original Loot index of an item_id. 

## Testing
Since creating the prefixes and suffixes also require random numbers, I had to modify the tests so that generate_item_suffix, generate_name_suffix and generate_name_prefix also take a random number as argument.
To generate the random number I've made use of the fuzzing strategies of Protostar to make sure that the tests pass for any random number between 0 and 101.
