### PR TITLE
feat Allow approved modules to forbid travel

### DIFF
--- a/contracts/settling_game/modules/travel/Travel.cairo
+++ b/contracts/settling_game/modules/travel/Travel.cairo
@@ -60,7 +60,7 @@ func TravelAction_2(
 // @param traveller_nested_id: NestedID
 @storage_var
 func cannot_travel(
-    traveller_contract_id: felt, traveller_token_id: felt, traveller_nested_id: felt
+    traveller_contract_id: felt, traveller_token_id: Uint256, traveller_nested_id: felt
 ) -> (cannot_travel: felt) {
 }
 
@@ -119,7 +119,7 @@ func upgrade{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
 // @param traveller_nested_id: NestedID
 @external
 func allow_travel{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    traveller_contract_id: felt, traveller_token_id: felt, traveller_nested_id: felt
+    traveller_contract_id: felt, traveller_token_id: Uint256, traveller_nested_id: felt
 ) -> () {
     Module.only_approved();
     cannot_travel.write(traveller_contract_id, traveller_token_id, traveller_nested_id, FALSE);
@@ -133,7 +133,7 @@ func allow_travel{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_pt
 // @param traveller_nested_id: NestedID
 @external
 func forbid_travel{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    traveller_contract_id: felt, traveller_token_id: felt, traveller_nested_id: felt
+    traveller_contract_id: felt, traveller_token_id: Uint256, traveller_nested_id: felt
 ) -> () {
     Module.only_approved();
     cannot_travel.write(traveller_contract_id, traveller_token_id, traveller_nested_id, TRUE);
@@ -290,14 +290,14 @@ func get_travel_distance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_c
 
 // @notice Assert that an item can travel (army, adventurer), by default all items can travel
 func assert_can_travel{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    traveller_contract_id: felt, traveller_token_id: felt, traveller_nested_id: felt
+    traveller_contract_id: felt, traveller_token_id: Uint256, traveller_nested_id: felt
 ) -> () {
     with_attr error_message("Travel: cannot move this item") {
         let (forbid_to_travel) = cannot_travel.read(
             traveller_contract_id, traveller_token_id, traveller_nested_id
         );
 
-        assert forbid_to_travel = 0;
+        assert forbid_to_travel = FALSE;
     }
     return ();
 }

--- a/tests/protostar/settling_game/travel/test_travel.cairo
+++ b/tests/protostar/settling_game/travel/test_travel.cairo
@@ -3,8 +3,11 @@
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.math import unsigned_div_rem, sqrt
 from starkware.cairo.common.pow import pow
+from starkware.starknet.common.syscalls import get_contract_address
+from starkware.cairo.common.bool import TRUE, FALSE
 
 from contracts.settling_game.modules.travel.library import Travel, PRECISION
+from contracts.settling_game.modules.travel.travel import assert_can_travel
 
 from contracts.settling_game.utils.constants import SECONDS_PER_KM
 from contracts.settling_game.utils.game_structs import Point
@@ -18,6 +21,28 @@ const TEST_Y1 = (-96200) + offset;
 const TEST_X2 = (685471) + offset;
 
 const TEST_Y2 = (419800) + offset;
+
+const TRAVELLER_CONTRACT_ID = 1;
+const TRAVELLER_TOKEN_ID = 1;
+const TRAVELLER_NESTED_ID = 1;
+
+@external
+func test_travel_when_forbid_should_fail{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+}() -> () {
+    let (self_address) = get_contract_address();
+    %{ store(ids.self_address, "cannot_travel", [1], [ids.TRAVELLER_CONTRACT_ID, ids.TRAVELLER_TOKEN_ID, ids.TRAVELLER_NESTED_ID]) %}
+    %{ expect_revert() %}
+    assert_can_travel(TRAVELLER_CONTRACT_ID, TRAVELLER_TOKEN_ID, TRAVELLER_NESTED_ID);
+    return ();
+}
+
+@external
+func test_travel_when_allowed{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    ) -> () {
+    assert_can_travel(TRAVELLER_CONTRACT_ID, TRAVELLER_TOKEN_ID, TRAVELLER_NESTED_ID);
+    return ();
+}
 
 @external
 func test_calculate_distance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {

--- a/tests/protostar/settling_game/travel/test_travel.cairo
+++ b/tests/protostar/settling_game/travel/test_travel.cairo
@@ -5,9 +5,15 @@ from starkware.cairo.common.math import unsigned_div_rem, sqrt
 from starkware.cairo.common.pow import pow
 from starkware.starknet.common.syscalls import get_contract_address
 from starkware.cairo.common.bool import TRUE, FALSE
+from starkware.cairo.common.uint256 import Uint256
 
 from contracts.settling_game.modules.travel.library import Travel, PRECISION
-from contracts.settling_game.modules.travel.travel import assert_can_travel
+from contracts.settling_game.modules.travel.travel import (
+    allow_travel,
+    forbid_travel,
+    assert_can_travel,
+    travel,
+)
 
 from contracts.settling_game.utils.constants import SECONDS_PER_KM
 from contracts.settling_game.utils.game_structs import Point
@@ -31,16 +37,16 @@ func test_travel_when_forbid_should_fail{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
 }() -> () {
     let (self_address) = get_contract_address();
-    %{ store(ids.self_address, "cannot_travel", [1], [ids.TRAVELLER_CONTRACT_ID, ids.TRAVELLER_TOKEN_ID, ids.TRAVELLER_NESTED_ID]) %}
+    %{ store(ids.self_address, "cannot_travel", [1], [ids.TRAVELLER_CONTRACT_ID, ids.TRAVELLER_TOKEN_ID, 0, ids.TRAVELLER_NESTED_ID]) %}
     %{ expect_revert() %}
-    assert_can_travel(TRAVELLER_CONTRACT_ID, TRAVELLER_TOKEN_ID, TRAVELLER_NESTED_ID);
+    assert_can_travel(TRAVELLER_CONTRACT_ID, Uint256(TRAVELLER_TOKEN_ID, 0), TRAVELLER_NESTED_ID);
     return ();
 }
 
 @external
 func test_travel_when_allowed{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     ) -> () {
-    assert_can_travel(TRAVELLER_CONTRACT_ID, TRAVELLER_TOKEN_ID, TRAVELLER_NESTED_ID);
+    assert_can_travel(TRAVELLER_CONTRACT_ID, Uint256(TRAVELLER_TOKEN_ID, 0), TRAVELLER_NESTED_ID);
     return ();
 }
 


### PR DESCRIPTION
**Allow approved modules to restrain an item from travelling**

## Issue
I am currently working on the Bastion module, which needs to track the number of armies that are defending a bastion (a location on the map). 
Armies can travel in and out of the bastion using "travel" but they have to actively call a "defend" entrypoint to become a defender. This allows the Bastion Module to track the number of defenders of a bastion for example. Once an army becomes a defender, they should not be able to travel out of the bastion without removing themselves from the defense first. At the moment, the travel function allows any item to travel without constraint except when it is a defending army of a realm.  

## Solution
What I propose is a general solution that adds a new storage_var in the Travel module called "cannot_travel", which tracks if items are forbidden to travel. By default all the items can travel, and approved modules can call a function to forbid travel or allow travel. A check is then made everytime we travel that the item is allowed to travel. 

## Changes
- a new storage_var "cannot_travel"
- 2 new external functions "allow_travel" and "forbid_travel"
- 1 new internal function "assert_can_travel"
- refactoring of "travel" to include "assert_can_travel"

✅ Since all items default to cannot_travel = false by default, adding this feature would not have any breaking changes